### PR TITLE
fix(tool): include original input in combined keyboard layouts

### DIFF
--- a/src/Tool/KeyboardLayout.php
+++ b/src/Tool/KeyboardLayout.php
@@ -83,7 +83,9 @@ final class KeyboardLayout {
 	 * @throws Exception
 	 */
 	public static function combineMany(string $input, array $langs): array {
-		$result = [];
+		// Add original phrase as first result to cover case
+		// when we do not have original language and we make sure we keep it
+		$result = [$input];
 		$pairs = static::getPairs($langs);
 		foreach ($pairs as $target => $sources) {
 			$self = new static($target);

--- a/test/BuddyCore/Tool/KeyboardLayoutTest.php
+++ b/test/BuddyCore/Tool/KeyboardLayoutTest.php
@@ -72,7 +72,7 @@ class KeyboardLayoutTest extends TestCase {
 		$langs = ['ru', 'us'];
 		$input = 'руддщ world';
 		$result = KeyboardLayout::combineMany($input, $langs);
-		$this->assertEquals(['hello world', 'руддщ цщкдв'], $result);
+		$this->assertEquals(['руддщ world', 'hello world', 'руддщ цщкдв'], $result);
 
 		$langs = ['ru', 'us', 'de'];
 		$input = 'руддщ world';

--- a/test/BuddyCore/Tool/KeyboardLayoutTest.php
+++ b/test/BuddyCore/Tool/KeyboardLayoutTest.php
@@ -78,6 +78,6 @@ class KeyboardLayoutTest extends TestCase {
 		$input = 'руддщ world';
 		$result = KeyboardLayout::combineMany($input, $langs);
 		// We get unique combinations as output, but real combinatinos are 6
-		$this->assertEquals(['hello world','руддщ world','руддщ цщкдв'], $result);
+		$this->assertEquals(['руддщ world','hello world', 'руддщ цщкдв'], $result);
 	}
 }


### PR DESCRIPTION
- Add original phrase as first result to preserve input when original language is missing
- Ensure original input is always retained in combined results