### PR TITLE
refactor(core): move ConfigManager from buddy to core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor
 cache
 docs
-
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">test/</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="Manticore Buddy Core">
+    <directory>test/</directory>
+  </testsuite>
+</phpunit>

--- a/src/ManticoreSearch/Client.php
+++ b/src/ManticoreSearch/Client.php
@@ -20,6 +20,7 @@ use Manticoresearch\Buddy\Core\Error\ManticoreSearchClientError;
 use Manticoresearch\Buddy\Core\Network\Struct;
 use Manticoresearch\Buddy\Core\Tool\Arrays;
 use Manticoresearch\Buddy\Core\Tool\Buddy;
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
 use RuntimeException;
 use Swoole\ConnectionPool;
 use Swoole\Coroutine;
@@ -514,7 +515,7 @@ class Client {
 			// If the key is plugin_dir check env first and after choose
 			// most priority
 			if ($key === 'common.plugin_dir') {
-				$value = getenv('PLUGIN_DIR') ?: $value;
+				$value = ConfigManager::get('PLUGIN_DIR') ?: $value;
 			}
 			$settings->push(
 				new Map(

--- a/src/Tool/Buddy.php
+++ b/src/Tool/Buddy.php
@@ -51,7 +51,7 @@ final class Buddy {
 	 * @return void
 	 */
 	public static function debug(string $message, string $eol = PHP_EOL, int $verbosity = 1): void {
-		$debug = (int)getenv('DEBUG');
+		$debug = ConfigManager::getInt('DEBUG');
 		if ($debug < $verbosity) {
 			return;
 		}

--- a/src/Tool/ConfigManager.php
+++ b/src/Tool/ConfigManager.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 /*
-  Copyright (c) 2024, Manticore Software LTD (https://manticoresearch.com)
+  Copyright (c) 2025, Software LTD (https://manticoresearch.com)
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 3 or any later

--- a/src/Tool/ConfigManager.php
+++ b/src/Tool/ConfigManager.php
@@ -1,0 +1,190 @@
+<?php declare(strict_types=1);
+
+/*
+  Copyright (c) 2024, Manticore Software LTD (https://manticoresearch.com)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 or any later
+  version. You should have received a copy of the GPL license along with this
+  program; if you did not, you can find it at http://www.gnu.org/
+*/
+
+namespace Manticoresearch\Buddy\Core\Tool;
+
+use RuntimeException;
+use Swoole\Table;
+
+/**
+ * Shared configuration manager using Swoole Table for multi-worker environments
+ * Provides thread-safe configuration storage accessible across all Swoole workers
+ */
+final class ConfigManager {
+	/** @var ?Table */
+	private static ?Table $table = null;
+
+	/** @var bool */
+	private static bool $initialized = false;
+
+	/**
+	 * Initialize the configuration table with current environment values
+	 * Must be called before Swoole server starts
+	 *
+	 * @return void
+	 * @throws RuntimeException
+	 */
+	public static function init(): void {
+		if (self::$initialized) {
+			return;
+		}
+
+		self::$table = new Table(64);
+		self::$table->column('value', Table::TYPE_STRING, 256);
+
+		if (!self::$table->create()) {
+			throw new RuntimeException('Failed to create configuration table');
+		}
+
+		// Initialize with current environment values
+		self::initializeFromEnvironment();
+		self::$initialized = true;
+	}
+
+	/**
+	 * Set a configuration value
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @return void
+	 * @throws RuntimeException
+	 */
+	public static function set(string $key, string $value): void {
+		self::ensureInitialized();
+		assert(self::$table !== null);
+		self::$table->set($key, ['value' => $value]);
+	}
+
+	/**
+	 * Get a configuration value
+	 *
+	 * @param string $key
+	 * @param string $default
+	 * @return string
+	 * @throws RuntimeException
+	 */
+	public static function get(string $key, string $default = ''): string {
+		self::ensureInitialized();
+		assert(self::$table !== null);
+		$row = self::$table->get($key);
+		return $row !== false && is_array($row) && isset($row['value']) ? (string)$row['value'] : $default;
+	}
+
+	/**
+	 * Get a configuration value as integer
+	 *
+	 * @param string $key
+	 * @param int $default
+	 * @return int
+	 * @throws RuntimeException
+	 */
+	public static function getInt(string $key, int $default = 0): int {
+		return (int)self::get($key, (string)$default);
+	}
+
+	/**
+	 * Get a configuration value as boolean
+	 *
+	 * @param string $key
+	 * @param bool $default
+	 * @return bool
+	 * @throws RuntimeException
+	 */
+	public static function getBool(string $key, bool $default = false): bool {
+		return (bool)self::get($key, (string)$default);
+	}
+
+
+	/**
+	 * Check if a configuration key exists
+	 *
+	 * @param string $key
+	 * @return bool
+	 * @throws RuntimeException
+	 */
+	public static function has(string $key): bool {
+		self::ensureInitialized();
+		assert(self::$table !== null);
+		return self::$table->exist($key);
+	}
+
+	/**
+	 * Get all configuration values
+	 *
+	 * @return array<string, string>
+	 * @throws RuntimeException
+	 */
+	public static function getAll(): array {
+		self::ensureInitialized();
+		assert(self::$table !== null);
+		$config = [];
+		foreach (self::$table as $key => $row) {
+			if (!is_array($row) || !isset($row['value'])) {
+				continue;
+			}
+
+			$config[$key] = (string)$row['value'];
+		}
+		return $config;
+	}
+
+	/**
+	 * Initialize configuration with default values
+	 * Values will be set by CliArgsProcessor and other components
+	 *
+	 * @return void
+	 */
+	private static function initializeFromEnvironment(): void {
+		// Initialize with default values - these will be overridden by CliArgsProcessor
+		$defaultVars = [
+			'DEBUG' => '0',
+			'THREADS' => (string)swoole_cpu_num(),
+			'TELEMETRY' => '1',
+			'TELEMETRY_PERIOD' => '300',
+			'LISTEN' => '127.0.0.1:9308',
+			'BIND_HOST' => '127.0.0.1',
+			'BIND_PORT' => '',
+			'PLUGIN_DIR' => '',
+		];
+
+		foreach ($defaultVars as $key => $value) {
+			// Only set if not already set (allows CliArgsProcessor to override)
+			assert(self::$table !== null);
+			if (self::$table->exist($key)) {
+				continue;
+			}
+
+			self::$table->set($key, ['value' => $value]);
+		}
+	}
+
+	/**
+	 * Ensure the configuration manager is initialized
+	 *
+	 * @return void
+	 * @throws RuntimeException
+	 */
+	private static function ensureInitialized(): void {
+		if (!self::$initialized || self::$table === null) {
+			throw new RuntimeException('ConfigManager not initialized. Call ConfigManager::init() first.');
+		}
+	}
+
+	/**
+	 * Reset the configuration manager (mainly for testing)
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		self::$table = null;
+		self::$initialized = false;
+	}
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 /*
-  Copyright (c) 2024, Manticore Software LTD (https://manticoresearch.com)
+  Copyright (c) 2025, Manticore Software LTD (https://manticoresearch.com)
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 3 or any later

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/*
+  Copyright (c) 2024, Manticore Software LTD (https://manticoresearch.com)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 3 or any later
+  version. You should have received a copy of the GPL license along with this
+  program; if you did not, you can find it at http://www.gnu.org/
+*/
+
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
+
+ConfigManager::init();
+

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -12,4 +12,3 @@
 use Manticoresearch\Buddy\Core\Tool\ConfigManager;
 
 ConfigManager::init();
-

--- a/test/src/runtime.php
+++ b/test/src/runtime.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
+
 /*
   Copyright (c) 2023, Manticore Software LTD (https://manticoresearch.com)
 
@@ -21,3 +23,4 @@ include_once __DIR__ . DIRECTORY_SEPARATOR
 const MOCK_BUDDY_VERSION = '1.0.0';
 
 Manticoresearch\Buddy\Core\Tool\Buddy::setVersionFile(MOCK_BUDDY_VERSION);
+

--- a/test/src/runtime.php
+++ b/test/src/runtime.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 
-use Manticoresearch\Buddy\Core\Tool\ConfigManager;
-
 /*
   Copyright (c) 2023, Manticore Software LTD (https://manticoresearch.com)
 
@@ -23,4 +21,3 @@ include_once __DIR__ . DIRECTORY_SEPARATOR
 const MOCK_BUDDY_VERSION = '1.0.0';
 
 Manticoresearch\Buddy\Core\Tool\Buddy::setVersionFile(MOCK_BUDDY_VERSION);
-


### PR DESCRIPTION
- Add ConfigManager to core for centralized config handling
- Replace getenv calls with ConfigManager in Client and Buddy tools
- Enable thread-safe config access across Swoole workers