### PR TITLE
fix(client): restore async pool capacity after request failures

### DIFF
--- a/src/ManticoreSearch/Client.php
+++ b/src/ManticoreSearch/Client.php
@@ -82,13 +82,7 @@ class Client {
 		}
 		$this->setServerUrl($url);
 		$this->setAuthToken($authToken);
-		$this->connectionPool = new ConnectionPool(
-			function () {
-				$client = new HttpClient($this->host, $this->port);
-				$client->set(['timeout' => -1]);
-				return $client;
-			}
-		);
+		$this->connectionPool = new ConnectionPool(fn() => $this->makeHttpClient());
 		$this->buddyVersion = Buddy::getVersion();
 		$this->clientMap = new Map;
 	}
@@ -98,14 +92,17 @@ class Client {
 	 * @return void
 	 */
 	public function __clone() {
-		$this->connectionPool = new ConnectionPool(
-			function () {
-				$client = new HttpClient($this->host, $this->port);
-				$client->set(['timeout' => -1]);
-				return $client;
-			}
-		);
+		$this->connectionPool = new ConnectionPool(fn() => $this->makeHttpClient());
 		$this->clientMap = new Map;
+	}
+
+	/**
+	 * @return HttpClient
+	 */
+	protected function makeHttpClient(): HttpClient {
+		$client = new HttpClient($this->host, $this->port);
+		$client->set(['timeout' => -1]);
+		return $client;
 	}
 
 	/**
@@ -368,14 +365,15 @@ class Client {
 		$client->setData($request);
 		$client->execute("/$path");
 		if ($client->errCode) {
+			$error = "Error while async request: {$client->errCode}: {$client->errMsg}";
+			$client->close();
+			$this->connectionPool->put($this->makeHttpClient());
 			/** @phpstan-ignore-next-line */
 			if ($client->errCode !== 104 || $try >= 3) {
-				$error = "Error while async request: {$client->errCode}: {$client->errMsg}";
 				throw new ManticoreSearchClientError($error);
 			}
 
 			Buddy::debug('Client: connection reset by peer, repeat: ' . (++$try));
-			$client->close();
 			goto request;
 		}
 		$result = $client->body;

--- a/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
+++ b/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
@@ -73,4 +73,80 @@ class ClientTest extends TestCase {
 	// 	$this->client->setServerUrl($url);
 	// }
 
+
+	public function testAsyncFailuresDoNotDrainConnectionPool(): void {
+		$executor = trim((string)shell_exec('command -v manticore-executor'));
+		if ($executor === '') {
+			$this->markTestSkipped('manticore-executor is required for the coroutine deadlock regression test');
+		}
+
+		$repoRoot = dirname(__DIR__, 4);
+		$autoloadCandidates = [
+			$repoRoot . '/vendor/autoload.php',
+			dirname($repoRoot, 2) . '/autoload.php',
+		];
+		$autoload = '';
+		foreach ($autoloadCandidates as $candidate) {
+			if (is_file($candidate)) {
+				$autoload = $candidate;
+				break;
+			}
+		}
+		$versionFile = $repoRoot . '/test/src/MOCK_APP_VERSION';
+		if ($autoload === '' || !is_file($versionFile)) {
+			$this->markTestSkipped('Required test bootstrap files are missing');
+		}
+
+		$scriptFile = tempnam(sys_get_temp_dir(), 'buddy-core-deadlock-');
+		if ($scriptFile === false) {
+			throw new \RuntimeException('Failed to create temporary script file');
+		}
+
+		$script = <<<'PHP'
+<?php declare(strict_types=1);
+
+require '__AUTOLOAD__';
+
+use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+use Manticoresearch\Buddy\Core\Tool\Buddy;
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
+use function Swoole\Coroutine\run;
+
+Buddy::setVersionFile('__VERSION_FILE__');
+ConfigManager::init();
+
+run(static function (): void {
+    $client = new Client('http://127.0.0.1:9');
+    for ($i = 1; $i <= 100; $i++) {
+        try {
+            $client->sendRequest('SHOW STATUS');
+            echo "ok {$i}\n";
+        } catch (Throwable $e) {
+            echo "err {$i}: " . $e->getMessage() . "\n";
+        }
+    }
+    echo "completed\n";
+});
+PHP;
+		$script = str_replace(
+			['__AUTOLOAD__', '__VERSION_FILE__'],
+			[addslashes($autoload), addslashes($versionFile)],
+			$script
+		);
+		file_put_contents($scriptFile, $script);
+
+		try {
+			$output = [];
+			$returnVar = 0;
+			exec($executor . ' ' . escapeshellarg($scriptFile) . ' 2>&1', $output, $returnVar);
+			$stdout = implode(PHP_EOL, $output);
+			$this->assertStringContainsString('completed', $stdout);
+			$this->assertStringNotContainsString('[FATAL ERROR]', $stdout);
+			$this->assertStringNotContainsString('all coroutines (count: 1) are asleep - deadlock!', $stdout);
+			$this->assertStringNotContainsString('Channel::~Channel()', $stdout);
+		} finally {
+			@unlink($scriptFile);
+		}
+	}
+
 }


### PR DESCRIPTION
Replace broken async HTTP clients in the ConnectionPool before throw/retry so repeated failures do not drain the pool and deadlock on the next get().

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4373