### PR TITLE
refactor!(search): introduce dedicated SystemClient class

### DIFF
--- a/src/ManticoreSearch/Client.php
+++ b/src/ManticoreSearch/Client.php
@@ -59,6 +59,9 @@ class Client {
 	/** @var ?string $delegatedUser */
 	protected ?string $delegatedUser = null;
 
+	/** @var ?SystemClient $systemClient */
+	protected ?SystemClient $systemClient = null;
+
 	/** @var string $buddyVersion */
 	protected string $buddyVersion;
 
@@ -166,18 +169,18 @@ class Client {
 	}
 
 	/**
-	 * Get a client clone that runs queries as the trusted system.buddy user.
+	 * Get a client bound to the trusted system.buddy user.
 	 *
 	 * Use it for internal plugin operations on system.* tables that must not
 	 * depend on the requesting user's permissions, while the original client
-	 * keeps the user's delegated identity.
+	 * keeps the user's delegated identity. The instance is memoized, so all
+	 * privileged queries issued through this client share one SystemClient
+	 * and its connection pool.
 	 *
-	 * @return static
+	 * @return SystemClient
 	 */
-	public function getSystemClient(): static {
-		$systemClient = clone $this;
-		$systemClient->setDelegatedUser(self::SYSTEM_USER);
-		return $systemClient;
+	public function getSystemClient(): SystemClient {
+		return $this->systemClient ??= new SystemClient($this->getServerUrl(), $this->authToken);
 	}
 
 	/**

--- a/src/ManticoreSearch/SystemClient.php
+++ b/src/ManticoreSearch/SystemClient.php
@@ -42,6 +42,7 @@ class SystemClient extends Client {
 	 * @return static
 	 * @throws LogicException always
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, SlevomatCodingStandard.Functions.UnusedParameter
 	public function setDelegatedUser(?string $user): static {
 		throw new LogicException('SystemClient always runs as ' . self::SYSTEM_USER);
 	}

--- a/src/ManticoreSearch/SystemClient.php
+++ b/src/ManticoreSearch/SystemClient.php
@@ -42,9 +42,11 @@ class SystemClient extends Client {
 	 * @return static
 	 * @throws LogicException always
 	 */
-	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, SlevomatCodingStandard.Functions.UnusedParameter
 	public function setDelegatedUser(?string $user): static {
-		throw new LogicException('SystemClient always runs as ' . self::SYSTEM_USER);
+		$requested = $user ?? 'null';
+		throw new LogicException(
+			"Cannot delegate to user '{$requested}': SystemClient always runs as " . self::SYSTEM_USER
+		);
 	}
 
 	/**

--- a/src/ManticoreSearch/SystemClient.php
+++ b/src/ManticoreSearch/SystemClient.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+namespace Manticoresearch\Buddy\Core\ManticoreSearch;
+
+use LogicException;
+
+/**
+ * Client permanently bound to the trusted system.buddy identity.
+ *
+ * Use it for internal plugin operations (system.* tables, background
+ * machinery) that must not depend on the requesting user's permissions.
+ * The identity is pinned at construction and cannot be re-delegated, so a
+ * SystemClient in a signature or property marks a privilege boundary that
+ * the type system enforces. Obtain it via Client::getSystemClient().
+ */
+class SystemClient extends Client {
+	/**
+	 * @param ?string $url
+	 * @param ?string $authToken
+	 * @return void
+	 */
+	public function __construct(?string $url = null, ?string $authToken = null) {
+		parent::__construct($url, $authToken);
+		parent::setDelegatedUser(self::SYSTEM_USER);
+	}
+
+	/**
+	 * The system identity is immutable: re-delegating a privileged client is
+	 * a programming error, so it fails loudly. clearDelegatedUser() routes
+	 * through here as well.
+	 *
+	 * @param ?string $user
+	 * @return static
+	 * @throws LogicException always
+	 */
+	public function setDelegatedUser(?string $user): static {
+		throw new LogicException('SystemClient always runs as ' . self::SYSTEM_USER);
+	}
+
+	/**
+	 * Already the system client: reuse this instance.
+	 * @return SystemClient
+	 */
+	public function getSystemClient(): SystemClient {
+		return $this;
+	}
+}

--- a/test/BuddyCore/Network/ManticoreSearch/SystemClientTest.php
+++ b/test/BuddyCore/Network/ManticoreSearch/SystemClientTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+use Manticoresearch\Buddy\Core\ManticoreSearch\SystemClient;
+use Manticoresearch\Buddy\CoreTest\Trait\TestInEnvironmentTrait;
+use PHPUnit\Framework\TestCase;
+
+class SystemClientTest extends TestCase {
+
+	use TestInEnvironmentTrait;
+
+	/**
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		self::setBuddyVersion();
+	}
+
+	public function testIdentityIsPinnedToSystemUser(): void {
+		$client = new SystemClient();
+		$this->assertSame(Client::SYSTEM_USER, $this->getDelegatedUser($client));
+	}
+
+	public function testSetDelegatedUserThrows(): void {
+		$client = new SystemClient();
+		$this->expectException(LogicException::class);
+		$client->setDelegatedUser('alice');
+	}
+
+	public function testClearDelegatedUserThrows(): void {
+		$client = new SystemClient();
+		$this->expectException(LogicException::class);
+		$client->clearDelegatedUser();
+	}
+
+	public function testGetSystemClientIsMemoizedAndKeepsOriginalIdentity(): void {
+		$client = new Client();
+		$client->setDelegatedUser('alice');
+
+		$system = $client->getSystemClient();
+		$this->assertInstanceOf(SystemClient::class, $system);
+		$this->assertSame($system, $client->getSystemClient());
+
+		$this->assertSame('alice', $this->getDelegatedUser($client));
+		$this->assertSame(Client::SYSTEM_USER, $this->getDelegatedUser($system));
+	}
+
+	public function testSystemClientReturnsItself(): void {
+		$system = (new Client())->getSystemClient();
+		$this->assertSame($system, $system->getSystemClient());
+	}
+
+	/**
+	 * @param Client $client
+	 * @return ?string
+	 */
+	private function getDelegatedUser(Client $client): ?string {
+		$ref = new ReflectionProperty(Client::class, 'delegatedUser');
+		/** @var ?string */
+		return $ref->getValue($client);
+	}
+}


### PR DESCRIPTION
- Create SystemClient to enforce immutable system identity
- Memoize SystemClient instance within Client to optimize connections
- Prevent identity re-delegation in SystemClient via LogicException
- Add unit tests for SystemClient identity pinning and memoization

BREAKING CHANGE: Client::getSystemClient now returns SystemClient instead of static