### PR TITLE
fix(client): prevent memory leak in connection pool

### DIFF
--- a/src/ManticoreSearch/Client.php
+++ b/src/ManticoreSearch/Client.php
@@ -90,7 +90,7 @@ class Client {
 		}
 		$this->setServerUrl($url);
 		$this->setAuthToken($authToken);
-		$this->connectionPool = new ConnectionPool(fn() => $this->makeHttpClient());
+		$this->connectionPool = $this->newConnectionPool();
 		$this->buddyVersion = Buddy::getVersion();
 		$this->clientMap = new Map;
 	}
@@ -100,17 +100,30 @@ class Client {
 	 * @return void
 	 */
 	public function __clone() {
-		$this->connectionPool = new ConnectionPool(fn() => $this->makeHttpClient());
+		$this->connectionPool = $this->newConnectionPool();
 		$this->clientMap = new Map;
 	}
 
 	/**
 	 * @return HttpClient
 	 */
-	protected function makeHttpClient(): HttpClient {
-		$client = new HttpClient($this->host, $this->port);
+	protected static function makeHttpClient(string $host, int $port): HttpClient {
+		$client = new HttpClient($host, $port);
 		$client->set(['timeout' => -1]);
 		return $client;
+	}
+
+	/**
+	 * Build a connection pool whose factory captures only scalars, so the pool
+	 * does not reference back to this Client. Without this, the Client<->pool
+	 * cycle keeps per-request cloned clients (and their keep-alive 9312 sockets)
+	 * alive until the GC cycle collector runs. See issue #686.
+	 * @return ConnectionPool
+	 */
+	private function newConnectionPool(): ConnectionPool {
+		$host = $this->host;
+		$port = $this->port;
+		return new ConnectionPool(static fn(): HttpClient => self::makeHttpClient($host, $port));
 	}
 
 	/**
@@ -124,6 +137,10 @@ class Client {
 		}
 		$this->host = (string)strtok($url, ':');
 		$this->port = (int)strtok(':');
+		// Rebuild the pool so post-construction URL changes take effect (e.g. tests).
+		if (isset($this->connectionPool)) {
+			$this->connectionPool = $this->newConnectionPool();
+		}
 		return $this;
 	}
 
@@ -390,7 +407,7 @@ class Client {
 		if ($client->errCode) {
 			$error = "Error while async request: {$client->errCode}: {$client->errMsg}";
 			$client->close();
-			$this->connectionPool->put($this->makeHttpClient());
+			$this->connectionPool->put(self::makeHttpClient($this->host, $this->port));
 			/** @phpstan-ignore-next-line */
 			if ($client->errCode !== 104 || $try >= 3) {
 				throw new ManticoreSearchClientError($error);

--- a/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
+++ b/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
@@ -149,4 +149,26 @@ PHP;
 		}
 	}
 
+	/**
+	 * Regression for the /metrics fd leak (issue #686). QueryProcessor clones the
+	 * shared client per request. If Client::__clone() builds a ConnectionPool whose
+	 * factory closure captures $this, Client and its pool form a reference cycle, so
+	 * the pooled keep-alive socket survives until the cycle collector runs -> fd leak.
+	 * A correct clone must be released by refcount the instant it goes out of scope.
+	 * @return void
+	 */
+	public function testClonedClientIsReleasedByRefcountWithoutCycleCollector(): void {
+		gc_collect_cycles();
+
+		$clone = clone $this->client;
+		$ref = WeakReference::create($clone);
+		unset($clone);
+
+		// No gc_collect_cycles() here on purpose: only refcounting may free it.
+		$this->assertNull(
+			$ref->get(),
+			'Cloned Client survived refcount drop: Client<->connectionPool reference cycle present (fd leak)'
+		);
+	}
+
 }


### PR DESCRIPTION
- Use static factory to avoid circular reference between Client and ConnectionPool
- Rebuild connection pool when server URL is updated
- Resolve socket persistence issue described in #686