### PR TITLE
feat(manticore): support Unix socket transport

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,8 @@ jobs:
           set -e
           ln -snf "$GITHUB_WORKSPACE" /workdir
           cd /workdir
-          composer require --dev code-lts/doctum -W
+          # twig-i18n-extension 4.0.1 is incompatible with Twig 3.21+.
+          composer require --dev code-lts/doctum 'twig/twig:<3.21' -W
           vendor/bin/doctum.php update config/doctum.php --ignore-parse-errors
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/src/ManticoreSearch/Client.php
+++ b/src/ManticoreSearch/Client.php
@@ -36,6 +36,7 @@ use Swoole\Lock;
 class Client {
 	const CONTENT_TYPE_HEADER = "Content-Type: application/x-www-form-urlencoded\n";
 	const URL_PREFIX = 'http://';
+	const UNIX_SOCKET_PREFIX = 'unix:/';
 	const HTTP_REQUEST_TIMEOUT = 300;
 	const DEFAULT_URL = 'http://127.0.0.1:9308';
 
@@ -132,11 +133,16 @@ class Client {
 	 * @return static
 	 */
 	public function setServerUrl($url): static {
-		if (str_starts_with($url, static::URL_PREFIX)) {
-			$url = substr($url, strlen(static::URL_PREFIX));
+		if (str_starts_with($url, static::UNIX_SOCKET_PREFIX)) {
+			$this->host = $url;
+			$this->port = 0;
+		} else {
+			if (str_starts_with($url, static::URL_PREFIX)) {
+				$url = substr($url, strlen(static::URL_PREFIX));
+			}
+			$this->host = (string)strtok($url, ':');
+			$this->port = (int)strtok(':');
 		}
-		$this->host = (string)strtok($url, ':');
-		$this->port = (int)strtok(':');
 		// Rebuild the pool so post-construction URL changes take effect (e.g. tests).
 		if (isset($this->connectionPool)) {
 			$this->connectionPool = $this->newConnectionPool();
@@ -158,6 +164,9 @@ class Client {
 	 * @return string
 	 */
 	public function getServerUrl(): string {
+		if (str_starts_with($this->host, static::UNIX_SOCKET_PREFIX)) {
+			return $this->host;
+		}
 		return static::URL_PREFIX . $this->host . ':' . $this->port;
 	}
 
@@ -430,6 +439,10 @@ class Client {
 	 * @return string
 	 */
 	protected function runSyncRequest(string $path, string $request, array $headers, string $method): string {
+		if (str_starts_with($this->host, static::UNIX_SOCKET_PREFIX)) {
+			return $this->runUnixSocketSyncRequest($path, $request, $headers, $method);
+		}
+
 		$headers['Connection'] = 'close';
 		$contextOptions = [
 			'http' => [
@@ -468,6 +481,70 @@ class Client {
 			$errorMessage = "Error while sync request: {$httpCode}: {$errorMessage}";
 			throw new ManticoreSearchClientError($errorMessage);
 		}
+	}
+
+	/**
+	 * Run a blocking HTTP request through a Unix-domain socket.
+	 * @param string $path
+	 * @param string $request
+	 * @param array<string,string> $headers
+	 * @param string $method
+	 * @return string
+	 */
+	protected function runUnixSocketSyncRequest(
+		string $path,
+		string $request,
+		array $headers,
+		string $method
+	): string {
+		$socketPath = substr($this->host, strlen('unix:'));
+		$socket = stream_socket_client(
+			"unix://{$socketPath}",
+			$errorCode,
+			$errorMessage,
+			static::HTTP_REQUEST_TIMEOUT
+		);
+		if ($socket === false) {
+			throw new ManticoreSearchClientError(
+				"Error while sync request: {$errorCode}: {$errorMessage}"
+			);
+		}
+
+		$headers['Host'] = 'localhost';
+		$headers['Connection'] = 'close';
+		$headers['Content-Length'] = (string)strlen($request);
+		$headerLines = array_map(
+			fn($key, $value) => "$key: $value",
+			array_keys($headers),
+			$headers
+		);
+		$payload = "{$method} /{$path} HTTP/1.1\r\n" . implode("\r\n", $headerLines)
+			. "\r\n\r\n{$request}";
+
+		try {
+			$written = 0;
+			$length = strlen($payload);
+			while ($written < $length) {
+				$bytes = fwrite($socket, substr($payload, $written));
+				if ($bytes === false || $bytes === 0) {
+					throw new ManticoreSearchClientError('Error while sync request: failed to write request');
+				}
+				$written += $bytes;
+			}
+
+			$response = stream_get_contents($socket);
+			if ($response === false) {
+				throw new ManticoreSearchClientError('Error while sync request: failed to read response');
+			}
+		} finally {
+			fclose($socket);
+		}
+
+		$headerEnd = strpos($response, "\r\n\r\n");
+		if ($headerEnd === false) {
+			throw new ManticoreSearchClientError('Error while sync request: invalid HTTP response');
+		}
+		return substr($response, $headerEnd + 4);
 	}
 
 	// Bunch of methods to help us reduce copy pasting, maybe we will move it out to separate class

--- a/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
+++ b/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
@@ -84,6 +84,7 @@ class ClientTest extends TestCase {
 		$this->runUnixSocketRequestTest(true);
 	}
 
+	/** @runInSeparateProcess */
 	public function testUnixSocketRequestInsideCoroutine(): void {
 		$this->runUnixSocketRequestTest(false);
 	}
@@ -121,12 +122,16 @@ class ClientTest extends TestCase {
 				$client->setForceSync();
 			}
 			$response = null;
-			/** @phpstan-ignore-next-line Swoole extension function is not included in the test stubs */
-			Swoole\Coroutine\run(
-				function () use ($client, &$response): void {
-					$response = $client->sendRequest('SHOW STATUS');
-				}
-			);
+			if ($forceSync) {
+				$response = $client->sendRequest('SHOW STATUS');
+			} else {
+				/** @phpstan-ignore-next-line Swoole extension function is not included in the test stubs */
+				Swoole\Coroutine\run(
+					function () use ($client, &$response): void {
+						$response = $client->sendRequest('SHOW STATUS');
+					}
+				);
+			}
 			$this->assertNotNull($response);
 			$this->assertStringContainsString('"total":1', $response->getBody());
 		} finally {

--- a/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
+++ b/test/BuddyCore/Network/ManticoreSearch/ClientTest.php
@@ -10,6 +10,7 @@
  */
 
 use Manticoresearch\Buddy\Core\ManticoreSearch\Client as HTTPClient;
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
 use Manticoresearch\Buddy\CoreTest\Trait\TestInEnvironmentTrait;
 use Manticoresearch\Buddy\CoreTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,7 @@ class ClientTest extends TestCase {
 	 */
 	public static function setUpBeforeClass(): void {
 		self::setBuddyVersion();
+		ConfigManager::init();
 	}
 
 	protected function setUp(): void {
@@ -64,6 +66,74 @@ class ClientTest extends TestCase {
 		$this->client->setServerUrl($url);
 		$this->assertEquals('localhost', $this->refCls->getProperty('host')->getValue($this->client));
 		$this->assertEquals(1000, $this->refCls->getProperty('port')->getValue($this->client));
+	}
+
+	public function testUnixSocketUrlSetOk(): void {
+		$url = 'unix:/tmp/manticore_data/searchd.sock';
+		$this->client->setServerUrl($url);
+
+		$this->assertEquals($url, $this->refCls->getProperty('host')->getValue($this->client));
+		$this->assertEquals(0, $this->refCls->getProperty('port')->getValue($this->client));
+		$this->assertEquals($url, $this->client->getServerUrl());
+
+		$systemClient = $this->client->getSystemClient();
+		$this->assertEquals($url, $systemClient->getServerUrl());
+	}
+
+	public function testUnixSocketSyncRequest(): void {
+		$this->runUnixSocketRequestTest(true);
+	}
+
+	public function testUnixSocketRequestInsideCoroutine(): void {
+		$this->runUnixSocketRequestTest(false);
+	}
+
+	private function runUnixSocketRequestTest(bool $forceSync): void {
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl is required for the Unix socket transport test');
+		}
+
+		$socketPath = sys_get_temp_dir() . '/buddy-core-' . getmypid() . '.sock';
+		$server = stream_socket_server("unix://{$socketPath}", $errorCode, $errorMessage);
+		$this->assertIsResource($server, $errorMessage);
+
+		$pid = pcntl_fork();
+		if ($pid === 0) {
+			$connection = stream_socket_accept($server, 5);
+			if ($connection === false) {
+				exit(1);
+			}
+			while (($line = fgets($connection)) !== false && trim($line) !== '') {
+			}
+			$body = '[{"total":1,"error":"","warning":"","columns":[],"data":[]}]';
+			fwrite(
+				$connection,
+				"HTTP/1.1 200 OK\r\nContent-Length: " . strlen($body) . "\r\nConnection: close\r\n\r\n{$body}"
+			);
+			fclose($connection);
+			fclose($server);
+			exit(0);
+		}
+
+		try {
+			$client = new HTTPClient("unix:{$socketPath}");
+			if ($forceSync) {
+				$client->setForceSync();
+			}
+			$response = null;
+			/** @phpstan-ignore-next-line Swoole extension function is not included in the test stubs */
+			Swoole\Coroutine\run(
+				function () use ($client, &$response): void {
+					$response = $client->sendRequest('SHOW STATUS');
+				}
+			);
+			$this->assertNotNull($response);
+			$this->assertStringContainsString('"total":1', $response->getBody());
+		} finally {
+			fclose($server);
+			pcntl_waitpid($pid, $status);
+			@unlink($socketPath);
+		}
 	}
 
 	// public function testResponseUrlSetFail(): void {


### PR DESCRIPTION
This allows Buddy to communicate with a Manticore instance exposed as:

```text
unix:/path/to/searchd.sock
```
instead of requiring a TCP HTTP listener. This is needed by Manticore's zero-configuration local mode, which exposes HTTP only through manticore_data/searchd.sock.
